### PR TITLE
Add consent modal

### DIFF
--- a/src/cfn/template.yaml
+++ b/src/cfn/template.yaml
@@ -14,7 +14,7 @@ Globals:
         MIN_CONFIDENCE: !Ref MinConfidence
         OBJECTS_OF_INTEREST_LABELS: !Join [",", !Ref ObjectsOfInterestLabels]
         REGION: !Ref AWS::Region
-        VERSION: '2.1'
+        VERSION: '2.2'
   Api:
     EndpointConfiguration: REGIONAL
     Cors:

--- a/src/web-ui/src/App.js
+++ b/src/web-ui/src/App.js
@@ -10,6 +10,7 @@ import CameraHelp from "./components/CameraHelp";
 import EngagementSummary from "./components/EngagementsSummary";
 import Header from "./components/Header";
 import SettingsHelp from "./components/SettingsHelp";
+import ConsentModal from "./components/ConsentModal";
 
 const App = () => {
   const [authState, setAuthState] = useState(undefined);
@@ -69,6 +70,7 @@ const App = () => {
         signedIn={signedIn}
         toggleRekognition={toggleRekognition}
       />
+      <ConsentModal></ConsentModal>
       {signedIn ? (
         <>
           <SettingsHelp show={!window.rekognitionSettings} />

--- a/src/web-ui/src/components/ConsentModal.js
+++ b/src/web-ui/src/components/ConsentModal.js
@@ -1,0 +1,40 @@
+import React from "react";
+import { Button, Modal } from "react-bootstrap";
+import useLocalStorage from "../hooks/useLocalStorage";
+
+const ConsentModal = () => {
+  const [hasConsent, setHasConsent] = useLocalStorage(
+    "rekognitionVirtualProctorConsent",
+    false
+  );
+
+  const onClick = () => {
+    setHasConsent(true);
+  };
+
+  return (
+    <Modal show={!hasConsent} backdrop="static" centered>
+      <Modal.Header>
+        <Modal.Title>Notice</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        This feature uses Amazon Web Services. Biometric identifiers and
+        biometric information (“biometric data”) may be collected, stored, and
+        used by Amazon Web Services for the purpose of comparing the image of an
+        individual with a stored image for analysis, verification, fraud, and
+        security purposes. Biometric information that is generated as part of
+        this process will be retained in line with Amazon Web Services privacy
+        policy. You hereby provide your express, informed, written release and
+        consent for Amazon Web Services to collect, use, and store your
+        biometric data as described herein.
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="primary" onClick={onClick}>
+          Accept
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default ConsentModal;

--- a/src/web-ui/src/hooks/useLocalStorage.js
+++ b/src/web-ui/src/hooks/useLocalStorage.js
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+const useLocalStorage = (key, fallback) => {
+  const [value, setValue] = useState(
+    JSON.parse(window.localStorage.getItem(key)) ?? fallback
+  );
+
+  useEffect(() => {
+    window.localStorage.setItem(key, value);
+  }, [key, value]);
+
+  return [value, setValue];
+};
+export default useLocalStorage;


### PR DESCRIPTION
*Issue #, if available:*

## Description of changes:*
This PR adds a modal to the app.
The modal provides a notice about the usage of biometric data when using the sample.

The modal is shown the first time the user opens the app. Once a user has acknowledged the notice, the user is not shown the notice again. 

I decided to keep all of the state self contained rather than keeping in the `App.js` component.
The `useLocalStorage` hook isn't comprehensive. It seemed overkill to add a new dependency for a fully fleshed out hook, so this is a basic version.

Here's what it looks like
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/17845406/220720175-9da184a7-96e5-400f-8bfc-5ddf9b8f01a1.png">

## Changes
* Add `useLocalStorage` hook
* Add `ConsentModal` component
* Display `ConsentModal` in app


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
